### PR TITLE
Add protocol.land published badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Argo
+[![protocol.land](https://arweave.net/eZp8gOeR8Yl_cyH9jJToaCrt2He1PHr0pR4o-mHbEcY)](https://protocol.land/#/repository/d8e7b91b-1025-47a5-9ea8-364451f496f9)
 
 Interact with [AO](https://ao.arweave.dev) in Go.
 


### PR DESCRIPTION
This PR adds Published on protocol.land badge to the README.

![pl-badge](https://github.com/ar-io/ar-io-node/assets/57343520/602301a9-414b-472c-99ca-78326bd60e75)
